### PR TITLE
BUGFIX - Unquoted shares corrected shown in CYA

### DIFF
--- a/app/viewmodels/checkAnswers/transferDetails/assetsMiniJourneys/quotedShares/QuotedSharesAmendContinueSummary.scala
+++ b/app/viewmodels/checkAnswers/transferDetails/assetsMiniJourneys/quotedShares/QuotedSharesAmendContinueSummary.scala
@@ -17,9 +17,9 @@
 package viewmodels.checkAnswers.transferDetails.assetsMiniJourneys.quotedShares
 
 import controllers.transferDetails.assetsMiniJourneys.AssetsMiniJourneysRoutes
-import models.{CheckMode, Mode, UserAnswers}
+import models.{Mode, UserAnswers}
 import play.api.i18n.Messages
-import queries.assets.{QuotedSharesQuery, UnquotedSharesQuery}
+import queries.assets.QuotedSharesQuery
 import uk.gov.hmrc.govukfrontend.views.viewmodels.summarylist.SummaryListRow
 import uk.gov.hmrc.hmrcfrontend.views.viewmodels.addtoalist.ListItem
 import utils.AppUtils
@@ -30,7 +30,7 @@ object QuotedSharesAmendContinueSummary extends AppUtils {
 
   def row(mode: Mode, userAnswers: UserAnswers)(implicit messages: Messages): Option[SummaryListRow] = {
 
-    val answers   = userAnswers.get(UnquotedSharesQuery)
+    val answers   = userAnswers.get(QuotedSharesQuery)
     val valueText = messages("quotedSharesAmendContinue.summary.value", answers.size)
 
     answers match {

--- a/app/viewmodels/checkAnswers/transferDetails/assetsMiniJourneys/unquotedShares/UnquotedSharesAmendContinueSummary.scala
+++ b/app/viewmodels/checkAnswers/transferDetails/assetsMiniJourneys/unquotedShares/UnquotedSharesAmendContinueSummary.scala
@@ -19,7 +19,7 @@ package viewmodels.checkAnswers.transferDetails.assetsMiniJourneys.unquotedShare
 import controllers.transferDetails.assetsMiniJourneys.AssetsMiniJourneysRoutes
 import models.{Mode, UserAnswers}
 import play.api.i18n.Messages
-import queries.assets.QuotedSharesQuery
+import queries.assets.UnquotedSharesQuery
 import uk.gov.hmrc.govukfrontend.views.viewmodels.summarylist.SummaryListRow
 import uk.gov.hmrc.hmrcfrontend.views.viewmodels.addtoalist.ListItem
 import utils.AppUtils
@@ -30,7 +30,7 @@ object UnquotedSharesAmendContinueSummary extends AppUtils {
 
   def row(mode: Mode, userAnswers: UserAnswers)(implicit messages: Messages): Option[SummaryListRow] = {
 
-    val answers   = userAnswers.get(QuotedSharesQuery)
+    val answers   = userAnswers.get(UnquotedSharesQuery)
     val valueText = messages("unquotedSharesAmendContinue.summary.value", answers.size)
 
     answers match {
@@ -50,7 +50,7 @@ object UnquotedSharesAmendContinueSummary extends AppUtils {
   }
 
   def rows(answers: UserAnswers): Seq[ListItem] = {
-    val maybeEntries = answers.get(QuotedSharesQuery)
+    val maybeEntries = answers.get(UnquotedSharesQuery)
     maybeEntries.getOrElse(Nil).zipWithIndex.map {
       case (entry, index) =>
         ListItem(


### PR DESCRIPTION
Unquoted share was showing in the Check Your Answer page after a Quoted share was added. This is no longer the case.